### PR TITLE
Added 3 new functions and fixed some major bugs

### DIFF
--- a/rcbasic_build/embedded_functions.bas
+++ b/rcbasic_build/embedded_functions.bas
@@ -390,4 +390,7 @@ function ReadByteBuffer(stream, ByRef buf, buf_size)
 function WindowEvent_Resize(win)
 sub SetWindowAutoClose( win, exit_on_close )
 sub SetWindowResizable(win, flag) 'new
-function SystemReturnOutput$(cmd$) 'new
+function SystemReturnStdOut$(cmd$) 'new
+function WindowMode(visible, fullscreen, resizable, borderless, highDPI)
+function WindowFlags(win)
+sub RestoreWindow(win)

--- a/rcbasic_build/rc_builtin.h
+++ b/rcbasic_build/rc_builtin.h
@@ -1009,8 +1009,19 @@ void init_embedded()
     embed_function("SetWindowResizable", ID_TYPE_SUB);
     add_embedded_arg("win", ID_TYPE_NUM);
     add_embedded_arg("flag", ID_TYPE_NUM);
-    embed_function("SystemReturnOutput$", ID_TYPE_FN_STR);
+    embed_function("SystemReturnStdOut$", ID_TYPE_FN_STR);
     add_embedded_arg("cmd$", ID_TYPE_STR);
+    embed_function("WindowMode", ID_TYPE_FN_NUM);
+    add_embedded_arg("visible", ID_TYPE_NUM);
+    add_embedded_arg("fullscreen", ID_TYPE_NUM);
+    add_embedded_arg("resizable", ID_TYPE_NUM);
+    add_embedded_arg("borderless", ID_TYPE_NUM);
+    add_embedded_arg("highDPI", ID_TYPE_NUM);
+    embed_function("WindowFlags", ID_TYPE_FN_NUM);
+    add_embedded_arg("win", ID_TYPE_NUM);
+    embed_function("RestoreWindow", ID_TYPE_SUB);
+    add_embedded_arg("win", ID_TYPE_NUM);
+
 
 }
 

--- a/rcbasic_build/tokenizer.h
+++ b/rcbasic_build/tokenizer.h
@@ -972,6 +972,18 @@ string rc_keywordToken(string sline)
         return "<num>3";
     else if(sline.compare("POWERSTATE_CHARGED")==0)
         return "<num>4";
+    else if(sline.compare("WINDOW_VISIBLE")==0)
+        return "<num>" + rc_intToString(SDL_WINDOW_SHOWN);
+    else if(sline.compare("WINDOW_FULLSCREEN")==0)
+        return "<num>" + rc_intToString(SDL_WINDOW_FULLSCREEN_DESKTOP);
+    else if(sline.compare("WINDOW_RESIZABLE")==0)
+        return "<num>" + rc_intToString(SDL_WINDOW_RESIZABLE);
+    else if(sline.compare("WINDOW_BORDERLESS")==0)
+        return "<num>" + rc_intToString(SDL_WINDOW_BORDERLESS);
+    else if(sline.compare("WINDOW_HIGHDPI")==0)
+        return "<num>" + rc_intToString(SDL_WINDOW_ALLOW_HIGHDPI);
+    else if(sline.compare("WINDOW_HIDDEN")==0)
+        return "<num>" + rc_intToString(SDL_WINDOW_HIDDEN);
     else
     {
         for(int i = 0; i < rc_constants.size(); i++)

--- a/rcbasic_runtime/main.cpp
+++ b/rcbasic_runtime/main.cpp
@@ -2223,8 +2223,17 @@ void func_130(uint64_t fn)
         case FN_SetWindowResizable:
             rc_media_setWindowResizable(SETWINDOWRESIZABLE_WIN, SETWINDOWRESIZABLE_FLAG);
             break;
-        case FN_SystemReturnOutput$:
-            rc_push_str( rc_intern_sysReturnOutput(SYSTEMRETURNOUTPUT$_CMD$) );
+        case FN_SystemReturnStdOut$:
+            rc_push_str( rc_intern_sysReturnOutput(SYSTEMRETURNSTDOUT$_CMD$) );
+            break;
+        case FN_WindowMode:
+            rc_push_num( rc_media_windowMode(WINDOWMODE_VISIBLE, WINDOWMODE_FULLSCREEN, WINDOWMODE_RESIZABLE, WINDOWMODE_BORDERLESS, WINDOWMODE_HIGHDPI) );
+            break;
+        case FN_WindowFlags:
+            rc_push_num( rc_media_windowFlags(WINDOWFLAGS_WIN) );
+            break;
+        case FN_RestoreWindow:
+            rc_media_restoreWindow(RESTOREWINDOW_WIN);
             break;
     }
 }
@@ -3078,7 +3087,7 @@ int main(int argc, char * argv[])
         }
         #endif // RC_WINDOWS
 
-    if(rc_filename.compare("-v")==0)
+    if(rc_filename.compare("--version")==0)
     {
         cout << "RCBASIC Runtime v3.14" << endl;
         return 0;

--- a/rcbasic_runtime/rc_defines.h
+++ b/rcbasic_runtime/rc_defines.h
@@ -1003,5 +1003,15 @@
 #define FN_SetWindowResizable 361
 #define SETWINDOWRESIZABLE_WIN num_var[0].nid_value[0].value[ num_var[0].byref_offset ]
 #define SETWINDOWRESIZABLE_FLAG num_var[1].nid_value[0].value[ num_var[1].byref_offset ]
-#define FN_SystemReturnOutput$ 362
-#define SYSTEMRETURNOUTPUT$_CMD$ str_var[0].sid_value[0].value[ str_var[0].byref_offset ]
+#define FN_SystemReturnStdOut$ 362
+#define SYSTEMRETURNSTDOUT$_CMD$ str_var[0].sid_value[0].value[ str_var[0].byref_offset ]
+#define FN_WindowMode 363
+#define WINDOWMODE_VISIBLE num_var[0].nid_value[0].value[ num_var[0].byref_offset ]
+#define WINDOWMODE_FULLSCREEN num_var[1].nid_value[0].value[ num_var[1].byref_offset ]
+#define WINDOWMODE_RESIZABLE num_var[2].nid_value[0].value[ num_var[2].byref_offset ]
+#define WINDOWMODE_BORDERLESS num_var[3].nid_value[0].value[ num_var[3].byref_offset ]
+#define WINDOWMODE_HIGHDPI num_var[4].nid_value[0].value[ num_var[4].byref_offset ]
+#define FN_WindowFlags 364
+#define WINDOWFLAGS_WIN num_var[0].nid_value[0].value[ num_var[0].byref_offset ]
+#define FN_RestoreWindow 365
+#define RESTOREWINDOW_WIN num_var[0].nid_value[0].value[ num_var[0].byref_offset ]


### PR DESCRIPTION
* Added WindowMode(), WindowFlags(), and RestoreWindow()
Fixed file read error with include stack in compiler
Fixed error when drawing canvases to back buffer during update ( canvases were being stretch to entire size of back buffer)
Made resizable windows use desktop resolution when maximized
Removed delay from GetVideoStats()
Cls() will now use clear color set by SetClearColor() for clearing back buffer
Removed limit check on SetCanvasOffset()